### PR TITLE
Update local.conf.sample and patch for 6.8 kernel transition support

### DIFF
--- a/conf/templates/default/local.conf.sample
+++ b/conf/templates/default/local.conf.sample
@@ -18,6 +18,10 @@ PATCHRESOLVE = "noop"
 # this doesn't mean anything to you.
 CONF_VERSION = "2"
 
+# Set preferred version of linux-intel to 6.8%
+PREFERRED_VERSION_linux-intel = "6.8%"
+
+SYSTEMD_DEFAULT_TARGET = "graphical.target"
 
 DISTRO_FEATURES:append = " security"
 DISTRO_FEATURES:append = " tpm"
@@ -26,14 +30,14 @@ IMAGE_INSTALL:append = " tpm2-tools tpm2-tss tpm2-abrmd"
 
 IMAGE_INSTALL:append = " bmaptool"
 IMAGE_INSTALL:append = " devmem2"
-IMAGE_INSTALL:append = " libgpiod-tools xfce4-startup"
+IMAGE_INSTALL:append = " libgpiod-tools"
 IMAGE_FSTYPES = "wic.bz2 wic.bmap"
 
 #Tools
 
 # Test Tools
 IMAGE_INSTALL:append = " alsa-utils alsa-tools ethtool tcpdump linuxptp fio glmark2 haveged hdparm hostapd i2c-tools iozone3 iptables iproute2 iperf3 libsocketcan \
-lmbench memtester mmc-utils net-tools spidev-test stress-ng stressapptest kernel-devsrc "
+lmbench memtester mmc-utils net-tools spidev-test stress-ng stressapptest kernel-devsrc customemoji "
 
 KERNEL_VERSION_SANITY_SKIP="1"
 

--- a/recipes-kernel/linux-intel/linux-intel/0001-Added-i2c-i801-support-for-sema.patch
+++ b/recipes-kernel/linux-intel/linux-intel/0001-Added-i2c-i801-support-for-sema.patch
@@ -1,17 +1,14 @@
-From b405a73ee7ba7af53d141ff5546d1d51f82036c5 Mon Sep 17 00:00:00 2001
-From: arun.tamilselvan <arun.tamilselvan@adlinktech.com>
-Date: Wed, 23 Oct 2024 13:17:21 +0530
-Subject: [PATCH] Added i2c-i801 support for sema
+From 02ca21893d9103f3b0aca08c6fa62016194d4eab Mon Sep 17 00:00:00 2001
+From: Asuvath <Asuvath.Monikandan@adlinktech.com>
+Date: Thu, 13 Feb 2025 14:56:34 +0530
+Subject: [PATCH] Added-i2c-i801-support-for-sema
 
 ---
- drivers/i2c/busses/i2c-i801.c | 915 ++++++++++++++++++++--------------
- 1 file changed, 531 insertions(+), 384 deletions(-)
- mode change 100644 => 100755 drivers/i2c/busses/i2c-i801.c
+ drivers/i2c/busses/i2c-i801.c | 1000 +++++++++++++++++++--------------
+ 1 file changed, 585 insertions(+), 415 deletions(-)
 
 diff --git a/drivers/i2c/busses/i2c-i801.c b/drivers/i2c/busses/i2c-i801.c
-old mode 100644
-new mode 100755
-index f6bc37f5eb3a..2316a36d0513
+index 738f52319e4d..2c67d6de4cae 100644
 --- a/drivers/i2c/busses/i2c-i801.c
 +++ b/drivers/i2c/busses/i2c-i801.c
 @@ -64,7 +64,6 @@
@@ -22,7 +19,7 @@ index f6bc37f5eb3a..2316a36d0513
   * Comet Lake (PCH)		0x02a3	32	hard	yes	yes	yes
   * Comet Lake-H (PCH)		0x06a3	32	hard	yes	yes	yes
   * Elkhart Lake (PCH)		0x4b23	32	hard	yes	yes	yes
-@@ -74,12 +73,6 @@
+@@ -74,13 +73,6 @@
   * Comet Lake-V (PCH)		0xa3a3	32	hard	yes	yes	yes
   * Alder Lake-S (PCH)		0x7aa3	32	hard	yes	yes	yes
   * Alder Lake-P (PCH)		0x51a3	32	hard	yes	yes	yes
@@ -32,10 +29,11 @@ index f6bc37f5eb3a..2316a36d0513
 - * Meteor Lake SoC-S (SOC)	0xae22	32	hard	yes	yes	yes
 - * Meteor Lake PCH-S (PCH)	0x7f23	32	hard	yes	yes	yes
 - * Birch Stream (SOC)		0x5796	32	hard	yes	yes	yes
+- * Arrow Lake-H (SOC)		0x7722	32	hard	yes	yes	yes
   *
   * Features supported by this driver:
   * Software PEC				no
-@@ -94,8 +87,6 @@
+@@ -95,8 +87,6 @@
   * See the file Documentation/i2c/busses/i2c-i801.rst for details.
   */
  
@@ -44,7 +42,7 @@ index f6bc37f5eb3a..2316a36d0513
  #include <linux/interrupt.h>
  #include <linux/module.h>
  #include <linux/pci.h>
-@@ -111,13 +102,11 @@
+@@ -112,13 +102,11 @@
  #include <linux/dmi.h>
  #include <linux/slab.h>
  #include <linux/string.h>
@@ -59,7 +57,7 @@ index f6bc37f5eb3a..2316a36d0513
  
  #if IS_ENABLED(CONFIG_I2C_MUX_GPIO) && defined CONFIG_DMI
  #include <linux/gpio/machine.h>
-@@ -141,13 +130,22 @@
+@@ -142,13 +130,22 @@
  
  /* PCI Address Constants */
  #define SMBBAR		4
@@ -82,7 +80,7 @@ index f6bc37f5eb3a..2316a36d0513
  /* Host configuration bits for SMBHSTCFG */
  #define SMBHSTCFG_HST_EN	BIT(0)
  #define SMBHSTCFG_SMB_SMI_EN	BIT(1)
-@@ -165,12 +163,15 @@
+@@ -166,12 +163,15 @@
  #define SMBAUXCTL_CRC		BIT(0)
  #define SMBAUXCTL_E32B		BIT(1)
  
@@ -99,7 +97,7 @@ index f6bc37f5eb3a..2316a36d0513
  #define I801_BLOCK_DATA		0x14
  #define I801_I2C_BLOCK_DATA	0x18	/* ICH5 and later */
  #define I801_BLOCK_PROC_CALL	0x1C
-@@ -196,7 +197,6 @@
+@@ -197,7 +197,6 @@
  #define SMBSLVSTS_HST_NTFY_STS	BIT(0)
  
  /* Host Notify Command register bits */
@@ -107,7 +105,7 @@ index f6bc37f5eb3a..2316a36d0513
  #define SMBSLVCMD_HST_NTFY_INTREN	BIT(0)
  
  #define STATUS_ERROR_FLAGS	(SMBHSTSTS_FAILED | SMBHSTSTS_BUS_ERR | \
-@@ -225,19 +225,13 @@
+@@ -226,20 +225,13 @@
  #define PCI_DEVICE_ID_INTEL_COLETOCREEK_SMBUS		0x23b0
  #define PCI_DEVICE_ID_INTEL_GEMINILAKE_SMBUS		0x31d4
  #define PCI_DEVICE_ID_INTEL_ICELAKE_LP_SMBUS		0x34a3
@@ -120,6 +118,7 @@ index f6bc37f5eb3a..2316a36d0513
 -#define PCI_DEVICE_ID_INTEL_ALDER_LAKE_M_SMBUS		0x54a3
 -#define PCI_DEVICE_ID_INTEL_BIRCH_STREAM_SMBUS		0x5796
  #define PCI_DEVICE_ID_INTEL_BROXTON_SMBUS		0x5ad4
+-#define PCI_DEVICE_ID_INTEL_ARROW_LAKE_H_SMBUS		0x7722
 -#define PCI_DEVICE_ID_INTEL_RAPTOR_LAKE_S_SMBUS		0x7a23
  #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_S_SMBUS		0x7aa3
 -#define PCI_DEVICE_ID_INTEL_METEOR_LAKE_P_SMBUS		0x7e22
@@ -127,7 +126,7 @@ index f6bc37f5eb3a..2316a36d0513
  #define PCI_DEVICE_ID_INTEL_LYNXPOINT_SMBUS		0x8c22
  #define PCI_DEVICE_ID_INTEL_WILDCATPOINT_SMBUS		0x8ca2
  #define PCI_DEVICE_ID_INTEL_WELLSBURG_SMBUS		0x8d22
-@@ -255,7 +249,6 @@
+@@ -257,7 +249,6 @@
  #define PCI_DEVICE_ID_INTEL_KABYLAKE_PCH_H_SMBUS	0xa2a3
  #define PCI_DEVICE_ID_INTEL_CANNONLAKE_H_SMBUS		0xa323
  #define PCI_DEVICE_ID_INTEL_COMETLAKE_V_SMBUS		0xa3a3
@@ -135,7 +134,7 @@ index f6bc37f5eb3a..2316a36d0513
  
  struct i801_mux_config {
  	char *gpio_chip;
-@@ -270,13 +263,12 @@ struct i801_priv {
+@@ -272,13 +263,12 @@ struct i801_priv {
  	struct i2c_adapter adapter;
  	unsigned long smba;
  	unsigned char original_hstcfg;
@@ -150,6 +149,26 @@ index f6bc37f5eb3a..2316a36d0513
  	u8 status;
  
  	/* Command state used by isr for byte-by-byte block transactions */
+@@ -289,6 +279,7 @@ struct i801_priv {
+ 	u8 *data;
+ 
+ #if IS_ENABLED(CONFIG_I2C_MUX_GPIO) && defined CONFIG_DMI
++	const struct i801_mux_config *mux_drvdata;
+ 	struct platform_device *mux_pdev;
+ 	struct gpiod_lookup_table *lookup;
+ #endif
+@@ -296,9 +287,10 @@ struct i801_priv {
+ 
+ 	/*
+ 	 * If set to true the host controller registers are reserved for
+-	 * ACPI AML use.
++	 * ACPI AML use. Protected by acpi_lock.
+ 	 */
+ 	bool acpi_reserved;
++	struct mutex acpi_lock;
+ };
+ 
+ #define FEATURE_SMBUS_PEC	BIT(0)
 @@ -338,14 +330,22 @@ static int i801_check_pre(struct i801_priv *priv)
  
  	status = inb_p(SMBHSTSTS(priv));
@@ -555,21 +574,21 @@ index f6bc37f5eb3a..2316a36d0513
  	}
  
 -	return i801_wait_intr(priv);
+-}
+-
+-static void i801_set_hstadd(struct i801_priv *priv, u8 addr, char read_write)
+-{
+-	outb_p((addr << 1) | (read_write & 0x01), SMBHSTADD(priv));
 +	status = i801_wait_intr(priv);
 +exit:
 +	return i801_check_post(priv, status);
  }
  
--static void i801_set_hstadd(struct i801_priv *priv, u8 addr, char read_write)
-+static int i801_set_block_buffer_mode(struct i801_priv *priv)
- {
--	outb_p((addr << 1) | (read_write & 0x01), SMBHSTADD(priv));
--}
--
 -/* Single value transaction function */
 -static int i801_simple_transaction(struct i801_priv *priv, union i2c_smbus_data *data,
 -				   u8 addr, u8 hstcmd, char read_write, int command)
--{
++static int i801_set_block_buffer_mode(struct i801_priv *priv)
+ {
 -	int xact, ret;
 -
 -	switch (command) {
@@ -718,7 +737,7 @@ index f6bc37f5eb3a..2316a36d0513
  
  	if (command == I2C_SMBUS_I2C_BLOCK_DATA
  	 && read_write == I2C_SMBUS_WRITE) {
-@@ -873,7 +851,9 @@ static s32 i801_access(struct i2c_adapter *adap, u16 addr,
+@@ -873,51 +851,136 @@ static s32 i801_access(struct i2c_adapter *adap, u16 addr,
  		       unsigned short flags, char read_write, u8 command,
  		       int size, union i2c_smbus_data *data)
  {
@@ -728,8 +747,12 @@ index f6bc37f5eb3a..2316a36d0513
 +	int ret = 0, xact = 0;
  	struct i801_priv *priv = i2c_get_adapdata(adap);
  
- 	mutex_lock(&priv->acpi_lock);
-@@ -884,41 +864,120 @@ static s32 i801_access(struct i2c_adapter *adap, u16 addr,
+-	if (priv->acpi_reserved)
++	mutex_lock(&priv->acpi_lock);
++	if (priv->acpi_reserved) {
++		mutex_unlock(&priv->acpi_lock);
+ 		return -EBUSY;
++	}
  
  	pm_runtime_get_sync(&priv->pci_dev->dev);
  
@@ -848,7 +871,7 @@ index f6bc37f5eb3a..2316a36d0513
 +	if (hwpec || block)
 +		outb_p(inb_p(SMBAUXCTL(priv)) &
 +		       ~(SMBAUXCTL_CRC | SMBAUXCTL_E32B), SMBAUXCTL(priv));
-+
+ 
 +	if (block)
 +		goto out;
 +	if (ret)
@@ -866,12 +889,15 @@ index f6bc37f5eb3a..2316a36d0513
 +			     (inb_p(SMBHSTDAT1(priv)) << 8);
 +		break;
 +	}
- 
++
 +out:
  	pm_runtime_mark_last_busy(&priv->pci_dev->dev);
  	pm_runtime_put_autosuspend(&priv->pci_dev->dev);
- 	mutex_unlock(&priv->acpi_lock);
-@@ -932,7 +991,6 @@ static u32 i801_func(struct i2c_adapter *adapter)
++	mutex_unlock(&priv->acpi_lock);
+ 	return ret;
+ }
+ 
+@@ -928,7 +991,6 @@ static u32 i801_func(struct i2c_adapter *adapter)
  
  	return I2C_FUNC_SMBUS_QUICK | I2C_FUNC_SMBUS_BYTE |
  	       I2C_FUNC_SMBUS_BYTE_DATA | I2C_FUNC_SMBUS_WORD_DATA |
@@ -879,7 +905,7 @@ index f6bc37f5eb3a..2316a36d0513
  	       I2C_FUNC_SMBUS_BLOCK_DATA | I2C_FUNC_SMBUS_WRITE_I2C_BLOCK |
  	       ((priv->features & FEATURE_SMBUS_PEC) ? I2C_FUNC_SMBUS_PEC : 0) |
  	       ((priv->features & FEATURE_BLOCK_PROC) ?
-@@ -950,13 +1008,9 @@ static void i801_enable_host_notify(struct i2c_adapter *adapter)
+@@ -946,13 +1008,9 @@ static void i801_enable_host_notify(struct i2c_adapter *adapter)
  	if (!(priv->features & FEATURE_HOST_NOTIFY))
  		return;
  
@@ -896,7 +922,7 @@ index f6bc37f5eb3a..2316a36d0513
  
  	/* clear Host Notify bit to allow a new notification */
  	outb_p(SMBSLVSTS_HST_NTFY_STS, SMBSLVSTS(priv));
-@@ -975,77 +1029,64 @@ static const struct i2c_algorithm smbus_algorithm = {
+@@ -971,78 +1029,64 @@ static const struct i2c_algorithm smbus_algorithm = {
  	.functionality	= i801_func,
  };
  
@@ -971,6 +997,7 @@ index f6bc37f5eb3a..2316a36d0513
 -	{ PCI_DEVICE_DATA(INTEL, METEOR_LAKE_SOC_S_SMBUS,	FEATURES_ICH5 | FEATURE_TCO_CNL) },
 -	{ PCI_DEVICE_DATA(INTEL, METEOR_LAKE_PCH_S_SMBUS,	FEATURES_ICH5 | FEATURE_TCO_CNL) },
 -	{ PCI_DEVICE_DATA(INTEL, BIRCH_STREAM_SMBUS,		FEATURES_ICH5 | FEATURE_TCO_CNL) },
+-	{ PCI_DEVICE_DATA(INTEL, ARROW_LAKE_H_SMBUS,		FEATURES_ICH5 | FEATURE_TCO_CNL) },
 +	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_82801AA_3) },
 +	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_82801AB_3) },
 +	{ PCI_DEVICE(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_INTEL_82801BA_2) },
@@ -1031,16 +1058,7 @@ index f6bc37f5eb3a..2316a36d0513
  	{ 0, }
  };
  
-@@ -1110,7 +1151,7 @@ static void dmi_check_onboard_device(u8 type, const char *name,
- 
- 		memset(&info, 0, sizeof(struct i2c_board_info));
- 		info.addr = dmi_devices[i].i2c_addr;
--		strscpy(info.type, dmi_devices[i].i2c_type, I2C_NAME_SIZE);
-+		strlcpy(info.type, dmi_devices[i].i2c_type, I2C_NAME_SIZE);
- 		i2c_new_client_device(adap, &info);
- 		break;
- 	}
-@@ -1186,7 +1227,7 @@ static acpi_status check_acpi_smo88xx_device(acpi_handle obj_handle,
+@@ -1183,7 +1227,7 @@ static acpi_status check_acpi_smo88xx_device(acpi_handle obj_handle,
  
  	kfree(info);
  
@@ -1049,7 +1067,7 @@ index f6bc37f5eb3a..2316a36d0513
  	return AE_CTRL_TERMINATE;
  
  smo88xx_not_found:
-@@ -1196,9 +1237,11 @@ static acpi_status check_acpi_smo88xx_device(acpi_handle obj_handle,
+@@ -1193,9 +1237,11 @@ static acpi_status check_acpi_smo88xx_device(acpi_handle obj_handle,
  
  static bool is_dell_system_with_lis3lv02d(void)
  {
@@ -1063,7 +1081,7 @@ index f6bc37f5eb3a..2316a36d0513
  		return false;
  
  	/*
-@@ -1209,9 +1252,11 @@ static bool is_dell_system_with_lis3lv02d(void)
+@@ -1206,9 +1252,11 @@ static bool is_dell_system_with_lis3lv02d(void)
  	 * accelerometer but unfortunately ACPI does not provide any other
  	 * information (like I2C address).
  	 */
@@ -1077,24 +1095,18 @@ index f6bc37f5eb3a..2316a36d0513
  }
  
  /*
-@@ -1237,7 +1282,6 @@ static const struct {
+@@ -1233,10 +1281,7 @@ static const struct {
+ 	 * Additional individual entries were added after verification.
  	 */
  	{ "Latitude 5480",      0x29 },
+-	{ "Precision 3540",     0x29 },
  	{ "Vostro V131",        0x1d },
 -	{ "Vostro 5568",        0x29 },
+-	{ "XPS 15 7590",        0x29 },
  };
  
  static void register_dell_lis3lv02d_i2c_device(struct i801_priv *priv)
-@@ -1262,7 +1306,7 @@ static void register_dell_lis3lv02d_i2c_device(struct i801_priv *priv)
- 
- 	memset(&info, 0, sizeof(struct i2c_board_info));
- 	info.addr = dell_lis3lv02d_devices[i].i2c_addr;
--	strscpy(info.type, "lis3lv02d", I2C_NAME_SIZE);
-+	strlcpy(info.type, "lis3lv02d", I2C_NAME_SIZE);
- 	i2c_new_client_device(&priv->adapter, &info);
- }
- 
-@@ -1274,11 +1318,11 @@ static void i801_probe_optional_slaves(struct i801_priv *priv)
+@@ -1273,11 +1318,11 @@ static void i801_probe_optional_slaves(struct i801_priv *priv)
  		return;
  
  	if (apanel_addr) {
@@ -1106,11 +1118,20 @@ index f6bc37f5eb3a..2316a36d0513
  
 +		memset(&info, 0, sizeof(struct i2c_board_info));
 +		info.addr = apanel_addr;
-+		strlcpy(info.type, "fujitsu_apanel", I2C_NAME_SIZE);
++		strscpy(info.type, "fujitsu_apanel", I2C_NAME_SIZE);
  		i2c_new_client_device(&priv->adapter, &info);
  	}
  
-@@ -1386,7 +1430,7 @@ static const struct dmi_system_id mux_dmi_table[] = {
+@@ -1289,7 +1334,7 @@ static void i801_probe_optional_slaves(struct i801_priv *priv)
+ 
+ 	/* Instantiate SPD EEPROMs unless the SMBus is multiplexed */
+ #if IS_ENABLED(CONFIG_I2C_MUX_GPIO)
+-	if (!priv->mux_pdev)
++	if (!priv->mux_drvdata)
+ #endif
+ 		i2c_register_spd(&priv->adapter);
+ }
+@@ -1385,20 +1430,17 @@ static const struct dmi_system_id mux_dmi_table[] = {
  };
  
  /* Setup multiplexing if needed */
@@ -1119,16 +1140,23 @@ index f6bc37f5eb3a..2316a36d0513
  {
  	struct device *dev = &priv->adapter.dev;
  	const struct i801_mux_config *mux_config;
-@@ -1395,7 +1439,7 @@ static void i801_add_mux(struct i801_priv *priv)
+ 	struct i2c_mux_gpio_platform_data gpio_data;
+ 	struct gpiod_lookup_table *lookup;
+-	const struct dmi_system_id *id;
  	int i;
  
- 	if (!priv->mux_drvdata)
+-	id = dmi_first_match(mux_dmi_table);
+-	if (!id)
 -		return;
+-
+-	mux_config = id->driver_data;
++	if (!priv->mux_drvdata)
 +		return 0;
- 	mux_config = priv->mux_drvdata;
++	mux_config = priv->mux_drvdata;
  
  	/* Prepare the platform data */
-@@ -1411,12 +1455,15 @@ static void i801_add_mux(struct i801_priv *priv)
+ 	memset(&gpio_data, 0, sizeof(struct i2c_mux_gpio_platform_data));
+@@ -1413,12 +1455,15 @@ static void i801_add_mux(struct i801_priv *priv)
  			      struct_size(lookup, table, mux_config->n_gpios + 1),
  			      GFP_KERNEL);
  	if (!lookup)
@@ -1148,7 +1176,7 @@ index f6bc37f5eb3a..2316a36d0513
  
  	/*
  	 * Register the mux device, we use PLATFORM_DEVID_NONE here
-@@ -1430,11 +1477,10 @@ static void i801_add_mux(struct i801_priv *priv)
+@@ -1432,11 +1477,10 @@ static void i801_add_mux(struct i801_priv *priv)
  				sizeof(struct i2c_mux_gpio_platform_data));
  	if (IS_ERR(priv->mux_pdev)) {
  		gpiod_remove_lookup_table(lookup);
@@ -1162,17 +1190,40 @@ index f6bc37f5eb3a..2316a36d0513
  }
  
  static void i801_del_mux(struct i801_priv *priv)
-@@ -1464,7 +1510,7 @@ static unsigned int i801_get_adapter_class(struct i801_priv *priv)
- 	return class;
+@@ -1444,54 +1488,106 @@ static void i801_del_mux(struct i801_priv *priv)
+ 	platform_device_unregister(priv->mux_pdev);
+ 	gpiod_remove_lookup_table(priv->lookup);
  }
++
++static unsigned int i801_get_adapter_class(struct i801_priv *priv)
++{
++	const struct dmi_system_id *id;
++	const struct i801_mux_config *mux_config;
++	unsigned int class = I2C_CLASS_HWMON | I2C_CLASS_SPD;
++	int i;
++
++	id = dmi_first_match(mux_dmi_table);
++	if (id) {
++		/* Remove branch classes from trunk */
++		mux_config = id->driver_data;
++		for (i = 0; i < mux_config->n_values; i++)
++			class &= ~mux_config->classes[i];
++
++		/* Remember for later */
++		priv->mux_drvdata = mux_config;
++	}
++
++	return class;
++}
  #else
 -static inline void i801_add_mux(struct i801_priv *priv) { }
 +static inline int i801_add_mux(struct i801_priv *priv) { return 0; }
  static inline void i801_del_mux(struct i801_priv *priv) { }
- 
- static inline unsigned int i801_get_adapter_class(struct i801_priv *priv)
-@@ -1473,49 +1519,75 @@ static inline unsigned int i801_get_adapter_class(struct i801_priv *priv)
- }
++
++static inline unsigned int i801_get_adapter_class(struct i801_priv *priv)
++{
++	return I2C_CLASS_HWMON | I2C_CLASS_SPD;
++}
  #endif
  
 +static const struct itco_wdt_platform_data spt_tco_platform_data = {
@@ -1219,10 +1270,10 @@ index f6bc37f5eb3a..2316a36d0513
 +
 +	pci_bus_read_config_dword(pci_dev->bus, devfn, SBREG_BAR, &base_addr);
 +	base64_addr = base_addr & 0xfffffff0;
-+
+ 
 +	pci_bus_read_config_dword(pci_dev->bus, devfn, SBREG_BAR + 0x4, &base_addr);
 +	base64_addr |= (u64)base_addr << 32;
- 
++
 +	/* Hide the P2SB device, if it was hidden before */
 +	if (hidden)
 +		pci_bus_write_config_byte(pci_dev->bus, devfn, 0xe1, hidden);
@@ -1267,7 +1318,24 @@ index f6bc37f5eb3a..2316a36d0513
  }
  
  static void i801_add_tco(struct i801_priv *priv)
-@@ -1603,39 +1675,55 @@ i801_acpi_io_handler(u32 function, acpi_physical_address address, u32 bits,
+@@ -1552,7 +1648,7 @@ i801_acpi_io_handler(u32 function, acpi_physical_address address, u32 bits,
+ 	 * further access from the driver itself. This device is now owned
+ 	 * by the system firmware.
+ 	 */
+-	i2c_lock_bus(&priv->adapter, I2C_LOCK_SEGMENT);
++	mutex_lock(&priv->acpi_lock);
+ 
+ 	if (!priv->acpi_reserved && i801_acpi_is_smbus_ioport(priv, address)) {
+ 		priv->acpi_reserved = true;
+@@ -1572,52 +1668,62 @@ i801_acpi_io_handler(u32 function, acpi_physical_address address, u32 bits,
+ 	else
+ 		status = acpi_os_write_port(address, (u32)*value, bits);
+ 
+-	i2c_unlock_bus(&priv->adapter, I2C_LOCK_SEGMENT);
++	mutex_unlock(&priv->acpi_lock);
+ 
+ 	return status;
+ }
  
  static int i801_acpi_probe(struct i801_priv *priv)
  {
@@ -1299,11 +1367,11 @@ index f6bc37f5eb3a..2316a36d0513
 +	adev = ACPI_COMPANION(&priv->pci_dev->dev);
 +	if (!adev)
 +		return;
- 
--	acpi_remove_address_space_handler(ah, ACPI_ADR_SPACE_SYSTEM_IO, i801_acpi_io_handler);
++
 +	acpi_remove_address_space_handler(adev->handle,
 +		ACPI_ADR_SPACE_SYSTEM_IO, i801_acpi_io_handler);
-+
+ 
+-	acpi_remove_address_space_handler(ah, ACPI_ADR_SPACE_SYSTEM_IO, i801_acpi_io_handler);
 +	mutex_lock(&priv->acpi_lock);
 +	if (priv->acpi_reserved)
 +		pm_runtime_put(&priv->pci_dev->dev);
@@ -1322,6 +1390,12 @@ index f6bc37f5eb3a..2316a36d0513
  	hstcfg &= ~SMBHSTCFG_I2C_EN;	/* SMBus timing */
  	hstcfg |= SMBHSTCFG_HST_EN;
  	pci_write_config_byte(priv->pci_dev, SMBHSTCFG, hstcfg);
+-}
+-
+-static void i801_restore_regs(struct i801_priv *priv)
+-{
+-	outb_p(priv->original_hstcnt, SMBHSTCNT(priv));
+-	pci_write_config_byte(priv->pci_dev, SMBHSTCFG, priv->original_hstcfg);
 +	return hstcfg;
  }
  
@@ -1331,8 +1405,18 @@ index f6bc37f5eb3a..2316a36d0513
  	int err, i;
  	struct i801_priv *priv;
  
-@@ -1653,7 +1741,70 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
- 	mutex_init(&priv->acpi_lock);
+@@ -1627,14 +1733,78 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
+ 
+ 	i2c_set_adapdata(&priv->adapter, priv);
+ 	priv->adapter.owner = THIS_MODULE;
+-	priv->adapter.class = I2C_CLASS_HWMON;
++	priv->adapter.class = i801_get_adapter_class(priv);
+ 	priv->adapter.algo = &smbus_algorithm;
+ 	priv->adapter.dev.parent = &dev->dev;
+-	acpi_use_parent_companion(&priv->adapter.dev);
++	ACPI_COMPANION_SET(&priv->adapter.dev, ACPI_COMPANION(&dev->dev));
+ 	priv->adapter.retries = 3;
++	mutex_init(&priv->acpi_lock);
  
  	priv->pci_dev = dev;
 -	priv->features = id->driver_data;
@@ -1403,7 +1487,7 @@ index f6bc37f5eb3a..2316a36d0513
  
  	/* Disable features on user request */
  	for (i = 0; i < ARRAY_SIZE(i801_feature_names); i++) {
-@@ -1663,10 +1814,6 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
+@@ -1644,10 +1814,6 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
  	}
  	priv->features &= ~disable_features;
  
@@ -1414,7 +1498,7 @@ index f6bc37f5eb3a..2316a36d0513
  	err = pcim_enable_device(dev);
  	if (err) {
  		dev_err(&dev->dev, "Failed to enable SMBus PCI device (%d)\n",
-@@ -1682,11 +1829,12 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
+@@ -1663,11 +1829,12 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
  			"SMBus base address uninitialized, upgrade BIOS\n");
  		return -ENODEV;
  	}
@@ -1430,7 +1514,7 @@ index f6bc37f5eb3a..2316a36d0513
  	if (err) {
  		dev_err(&dev->dev,
  			"Failed to request SMBus region 0x%lx-0x%Lx\n",
-@@ -1697,16 +1845,16 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
+@@ -1678,16 +1845,16 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
  	}
  
  	pci_read_config_byte(priv->pci_dev, SMBHSTCFG, &priv->original_hstcfg);
@@ -1450,7 +1534,7 @@ index f6bc37f5eb3a..2316a36d0513
  		dev_info(&dev->dev, "SPD Write Disable is set\n");
  
  	/* Clear special mode bits */
-@@ -1714,6 +1862,10 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
+@@ -1695,6 +1862,10 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
  		outb_p(inb_p(SMBAUXCTL(priv)) &
  		       ~(SMBAUXCTL_CRC | SMBAUXCTL_E32B), SMBAUXCTL(priv));
  
@@ -1461,7 +1545,7 @@ index f6bc37f5eb3a..2316a36d0513
  	/* Default timeout in interrupt mode: 200 ms */
  	priv->adapter.timeout = HZ / 5;
  
-@@ -1721,19 +1873,27 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
+@@ -1702,19 +1873,27 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
  		priv->features &= ~FEATURE_IRQ;
  
  	if (priv->features & FEATURE_IRQ) {
@@ -1494,7 +1578,7 @@ index f6bc37f5eb3a..2316a36d0513
  		if (err) {
  			dev_err(&dev->dev, "Failed to allocate irq %d: %d\n",
  				dev->irq, err);
-@@ -1743,22 +1903,12 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
+@@ -1724,32 +1903,21 @@ static int i801_probe(struct pci_dev *dev, const struct pci_device_id *id)
  	dev_info(&dev->dev, "SMBus using %s\n",
  		 priv->features & FEATURE_IRQ ? "PCI interrupt" : "polling");
  
@@ -1515,20 +1599,31 @@ index f6bc37f5eb3a..2316a36d0513
  	if (err) {
 -		platform_device_unregister(priv->tco_pdev);
  		i801_acpi_remove(priv);
+-		i801_restore_regs(priv);
  		return err;
  	}
-@@ -1784,7 +1934,9 @@ static void i801_remove(struct pci_dev *dev)
+ 
+ 	i801_enable_host_notify(&priv->adapter);
+ 
++	i801_probe_optional_slaves(priv);
+ 	/* We ignore errors - multiplexing is optional */
+ 	i801_add_mux(priv);
+-	i801_probe_optional_slaves(priv);
+ 
+ 	pci_set_drvdata(dev, priv);
+ 
+@@ -1766,19 +1934,17 @@ static void i801_remove(struct pci_dev *dev)
  {
  	struct i801_priv *priv = pci_get_drvdata(dev);
  
--	outb_p(priv->original_hstcnt, SMBHSTCNT(priv));
 +	pm_runtime_forbid(&dev->dev);
 +	pm_runtime_get_noresume(&dev->dev);
 +
  	i801_disable_host_notify(priv);
  	i801_del_mux(priv);
  	i2c_del_adapter(&priv->adapter);
-@@ -1793,10 +1945,6 @@ static void i801_remove(struct pci_dev *dev)
+ 	i801_acpi_remove(priv);
++	pci_write_config_byte(dev, SMBHSTCFG, priv->original_hstcfg);
  
  	platform_device_unregister(priv->tco_pdev);
  
@@ -1536,16 +1631,20 @@ index f6bc37f5eb3a..2316a36d0513
 -	if (!priv->acpi_reserved)
 -		pm_runtime_get_noresume(&dev->dev);
 -
+-	i801_restore_regs(priv);
+-
  	/*
  	 * do not call pci_disable_device(dev) since it can cause hard hangs on
  	 * some systems during power-off (eg. Fujitsu-Siemens Lifebook E8010)
-@@ -1808,16 +1956,15 @@ static void i801_shutdown(struct pci_dev *dev)
+@@ -1789,18 +1955,17 @@ static void i801_shutdown(struct pci_dev *dev)
+ {
  	struct i801_priv *priv = pci_get_drvdata(dev);
  
+-	i801_disable_host_notify(priv);
  	/* Restore config registers to avoid hard hang on some systems */
--	outb_p(priv->original_hstcnt, SMBHSTCNT(priv));
- 	i801_disable_host_notify(priv);
- 	pci_write_config_byte(dev, SMBHSTCFG, priv->original_hstcfg);
+-	i801_restore_regs(priv);
++	i801_disable_host_notify(priv);
++	pci_write_config_byte(dev, SMBHSTCFG, priv->original_hstcfg);
  }
  
 +#ifdef CONFIG_PM_SLEEP
@@ -1553,11 +1652,18 @@ index f6bc37f5eb3a..2316a36d0513
  {
  	struct i801_priv *priv = dev_get_drvdata(dev);
  
--	outb_p(priv->original_hstcnt, SMBHSTCNT(priv));
- 	pci_write_config_byte(priv->pci_dev, SMBHSTCFG, priv->original_hstcfg);
+-	i2c_mark_adapter_suspended(&priv->adapter);
+-	i801_restore_regs(priv);
+-
++	pci_write_config_byte(priv->pci_dev, SMBHSTCFG, priv->original_hstcfg);
  	return 0;
  }
-@@ -1831,18 +1978,18 @@ static int i801_resume(struct device *dev)
+ 
+@@ -1810,30 +1975,34 @@ static int i801_resume(struct device *dev)
+ 
+ 	i801_setup_hstcfg(priv);
+ 	i801_enable_host_notify(&priv->adapter);
+-	i2c_mark_adapter_resumed(&priv->adapter);
  
  	return 0;
  }
@@ -1580,6 +1686,28 @@ index f6bc37f5eb3a..2316a36d0513
  	},
  };
  
+-static int __init i2c_i801_init(struct pci_driver *drv)
++static int __init i2c_i801_init(void)
+ {
+ 	if (dmi_name_in_vendors("FUJITSU"))
+ 		input_apanel_init();
+-	return pci_register_driver(drv);
++	return pci_register_driver(&i801_driver);
++}
++
++static void __exit i2c_i801_exit(void)
++{
++	pci_unregister_driver(&i801_driver);
+ }
+ 
+ MODULE_AUTHOR("Mark D. Studebaker <mdsxyz123@yahoo.com>");
+@@ -1841,4 +2010,5 @@ MODULE_AUTHOR("Jean Delvare <jdelvare@suse.de>");
+ MODULE_DESCRIPTION("I801 SMBus driver");
+ MODULE_LICENSE("GPL");
+ 
+-module_driver(i801_driver, i2c_i801_init, pci_unregister_driver);
++module_init(i2c_i801_init);
++module_exit(i2c_i801_exit);
 -- 
-2.34.1
+2.25.1
 


### PR DESCRIPTION
Updated local.conf.sample with necessary patch for kernel linux-intel version 6.8 support.
