### PR TITLE
meta-adlink-intel: correct the grub prefix in the secure boot config

### DIFF
--- a/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/recipes-bsp/grub/grub-efi_%.bbappend
@@ -11,3 +11,10 @@ do_adlink_boot_menu_cmdline() {
     fi
 }
 addtask adlink_boot_menu_cmdline after do_install before do_sign
+
+do_adlink_fix_grub_prefix() {
+    if [ -f "${WORKDIR}/cfg" ]; then
+        sed -i 's|${GRUB_PREFIX_DIR}/EFI/BOOT/grub.cfg|${GRUB_PREFIX_DIR}/grub.cfg|' "${WORKDIR}/cfg"
+    fi
+}
+addtask adlink_fix_grub_prefix after do_compile before do_install


### PR DESCRIPTION
meta-secure-core builds the configuration embedded in grubx64.efi with

  search --file --set=root --hint-efi=($cmdpath) ${GRUB_PREFIX_DIR}/EFI/BOOT/grub.cfg

where GRUB_PREFIX_DIR is already /EFI/BOOT. The resulting image searches for /EFI/BOOT/EFI/BOOT/grub.cfg and stops at:

  error: no such device: /EFI/BOOT/EFI/BOOT/grub.cfg
  Boot configuration error - Attempting reboot

Correct the path in a task between do_compile and do_install. This keeps meta-secure-core unmodified and becomes a no-op once the path is fixed there.